### PR TITLE
Add subscription-based licensing with auto-renewal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,30 @@ A blockchain-based content licensing system built on the Stacks blockchain that 
 - Users to purchase time-based licenses for content
 - Automated license verification
 - License management and tracking
+- Subscription-based licensing with auto-renewal
 
 ## Features
 
 - Register new content with customizable pricing and license types
+- Configure multiple subscription periods (1 month, 3 months, 12 months etc)
 - Purchase content licenses with automated payments
+- Enable auto-renewal for subscription licenses
 - Check license validity
 - Update content pricing
 - Time-based license expiration
+- Renew existing licenses
 
 ## Usage
 
 The contract provides the following main functions:
 
-- register-content: Register new content with price and license type
-- purchase-license: Purchase a license for specific content
+- register-content: Register new content with price, license type and subscription periods
+- purchase-license: Purchase a license for specific content with optional auto-renewal
 - has-valid-license: Check if an address has a valid license
 - get-content-details: Get details about registered content
 - update-price: Update the price of registered content
+- get-license-details: Get details about a specific license
+- renew-license: Renew an existing auto-renewable license
 
 ## Implementation
 
@@ -32,3 +38,4 @@ The system uses Clarity smart contracts to manage:
 - License purchases and tracking
 - Automated payments
 - License verification
+- Subscription management and auto-renewals


### PR DESCRIPTION
This PR adds subscription-based licensing capabilities to the content license manager, allowing content creators to offer multiple subscription periods and enabling auto-renewal for licensees.

Key Changes:
- Added support for multiple subscription periods (1 month, 3 months, 12 months etc)
- Enhanced license data structure to include auto-renewal flag
- Added new function to renew existing licenses
- Added subscription period validation
- Updated tests to cover new subscription features
- Enhanced documentation

Benefits:
- More flexible licensing options for content creators
- Improved user experience with auto-renewal support
- Better subscription management capabilities
- Reduced friction for long-term content access

Implementation Details:
- Content registration now includes subscription period options
- License purchases require period selection and auto-renewal preference
- New renew-license function handles subscription extensions
- Enhanced error handling for invalid subscription periods
- Automated payment handling for renewals

Testing:
- Added new test cases for subscription features
- Verified backward compatibility
- Tested error cases and validation